### PR TITLE
Fix empty password on registry

### DIFF
--- a/src/api/routes/session.py
+++ b/src/api/routes/session.py
@@ -49,6 +49,11 @@ async def register_user(req_data: RegisterRequest):
 
     If the user already exists, return a 400 Bad Request error.
     """
+    if not req_data.email or not req_data.password or req_data.email == "" or req_data.password == "":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email and password are required."
+        )
 
     hashed_pw = pwd_context.hash(req_data.password)
 

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -110,7 +110,10 @@ def insert_api_key_in_db(user_email: str) -> Tuple[str, str]:
                         f"Account type: {account_type}"
                     )
                     return (row[0], account_type)
-                return ""
+                else:
+                    logger.error(
+                        f"Error inserting API key in DB. No row returned.")
+                    return ("", "")
     except Exception as e:
         logger.error(f"Error inserting API key in DB: {e}")
         return ""


### PR DESCRIPTION
Closes #36 

# Objective

This PR aims to add a check on the inputs of the registration

```console
❯ http --raw '{"email":"1234abc@gmail.com","password": ""}' localhost:8000/register
HTTP/1.1 400 Bad Request
Content-Length: 45
Content-Type: application/json
Date: Sun, 16 Feb 2025 16:57:16 GMT
Server: uvicorn

{
    "detail": "Email and password are required."
}
```